### PR TITLE
Bugfix: run executed program on correct core

### DIFF
--- a/energy_toolkit/cli.py
+++ b/energy_toolkit/cli.py
@@ -156,7 +156,7 @@ def plot(results, mode, headless):
         modep = PlotMode.str_to_plotmode(mode)
         plotter = Plotter(results, modep)
         debug_log("Parsing complete. Generating plot.")
-        plotter.plot(headless)
+        plotter.plot(results, headless)
     except click.ClickException as e:
         error_log("Errors during plotting found!")
         error_log(f"Reason: {e}")

--- a/energy_toolkit/energy_toolkit.py
+++ b/energy_toolkit/energy_toolkit.py
@@ -98,13 +98,13 @@ class EnergyToolkit:
                     while not measurement_valid:
                         # Take the current timer and energy reading
                         time_before = time.perf_counter()
-                        eng_before = RAPLInterface.read(self._vendor)
+                        eng_before = RAPLInterface.read(self._vendor, self._core)
 
                         # Execute the current program
                         program.execute(self._core)
 
                         # Read time and energy counter after measurement
-                        eng_after = RAPLInterface.read(self._vendor)
+                        eng_after = RAPLInterface.read(self._vendor, self._core)
                         time_after = time.perf_counter()
 
                         # Check for negative energy (possible overflow)

--- a/energy_toolkit/plotter.py
+++ b/energy_toolkit/plotter.py
@@ -127,7 +127,7 @@ class Plotter:
 
         return True
 
-    def plot(self, headless=False):
+    def plot(self, path="results", headless=False):
         """
         Plot the data stored in the object. If headless is true the plot will be saved as .pdf file,
         otherwise plotlys web rendering is used.
@@ -149,7 +149,7 @@ class Plotter:
             fig.write_image(f"figure_{current_time}.pdf", width=1000, height=520)
         else:
             current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"results/figure_{current_time}.html"
+            filename = f"{path}/figure_{current_time}.html"
             fig.write_html(filename)
 
     def _plot_lines(self, data) -> go.Figure:

--- a/energy_toolkit/program.py
+++ b/energy_toolkit/program.py
@@ -33,9 +33,6 @@ class Program:
         Execute the program on a specific core
         """
         try:
-            Logger().get_logger().debug(
-                "Different way to call subprocess...",
-            )
             fin = open(self._inputfile, "r") if self._inputfile else subprocess.DEVNULL
 
             subprocess.run(


### PR DESCRIPTION
1. The number of the core wasn't provided to the `RAPLInterface.read` method. Hence, the tool always read from the core 0, even if the `-c` option specified another core.

-> the fix is to just provide the core number as the parameter to the RAPLInterface

2. On my machine (AMD CPU) the executed program wasn't tied to its initial core and switched the core on which it was running after a few seconds. So, I wasn't able to get good measurements, because the energy usage was measured of a specified core (i.e. 0), even though the program was executed on another core.

-> my fix was to provide a function that ties the executed program to the correct core and supply it with the `preexec_fn` argument. This alone didn't work, so I had to provide the command as an array to the subprocess module and set `shell=False` (implicitly), because this caused to override the core set by the function from the `preexec_fn` argument.